### PR TITLE
Fix codesniffer and easy-coding-standard compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             -   run: yarn --cwd tests/Application install
             -   run: yarn --cwd tests/Application build
             -   run: (cd tests/Application && bin/console doctrine:database:create --if-not-exists --env=test -vvv)
-            -   run: (cd tests/Application && bin/console doctrine:schema:update --force --env=test -vvv)
+            -   run: (cd tests/Application && bin/console doctrine:schema:update --force --complete --env=test -vvv)
             -   run: (cd tests/Application && bin/console cache:clear --env=test -vvv)
             -   run: (cd tests/Application && bin/console cache:warmup --env=test -vvv)
             -   run: bin/phpstan.sh
@@ -70,7 +70,7 @@ jobs:
             -   run: yarn --cwd tests/Application install
             -   run: yarn --cwd tests/Application build
             -   run: (cd tests/Application && bin/console doctrine:database:create --if-not-exists --env=test -vvv)
-            -   run: (cd tests/Application && bin/console doctrine:schema:update --force --env=test -vvv)
+            -   run: (cd tests/Application && bin/console doctrine:schema:update --force --complete --env=test -vvv)
             -   run: (cd tests/Application && bin/console cache:clear --env=test -vvv)
             -   run: (cd tests/Application && bin/console cache:warmup --env=test -vvv)
             -   run: bin/phpstan.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
                         parameters:
                             sylius_version: [ "2.0" ]
                             php_version: [ "8.2", "8.3" ]
-                            symfony_version: [ "6.4", "7.1", "7.2" ]
+                            symfony_version: [ "6.4", "7.1" ]
 
 jobs:
     build:

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine AS node
 
-FROM ghcr.io/sylius/sylius-php:8.4-xdebug-alpine
+FROM ghcr.io/sylius/sylius-php:8.3-xdebug-alpine
 
 RUN apk add --no-cache \
     bash \

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /node_modules/
 /composer.lock
 /symfony.lock
+/.env
 /.envrc
 /phpunit_log
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: run init
+.PHONY: run init var ci
+
+MAKEFLAGS += --no-print-directory # to disable "make: Entering directory ..." messages
 
 APP_ENV ?= dev
 
@@ -16,6 +18,7 @@ init:
 	@make var
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:create --no-interaction --if-not-exists
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migrations:migrate --no-interaction
+	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:schema:update --no-interaction --complete --force
 	./bin-docker/php ./bin/console --env="$(APP_ENV)"  doctrine:migration:sync-metadata-storage
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" assets:install
 	./bin-docker/yarn --cwd=tests/Application install --pure-lockfile
@@ -24,17 +27,17 @@ init:
 
 init-tests:
 	which docker > /dev/null || (echo "Please install docker binary" && exit 1)
-	if command -v direnv &> /dev/null then \
+	if command -v direnv &> /dev/null; then \
 		cp --update=none .envrc.dist .envrc; \
 		direnv allow; \
 	fi
 	docker compose up -d
 	./bin-docker/composer install
-	rm -fr tests/Application/var/test
 	@make var
 	./bin-docker/php ./bin/console --env=test doctrine:database:drop --no-interaction --force --if-exists
 	./bin-docker/php ./bin/console --env=test doctrine:database:create --no-interaction --if-not-exists
 	./bin-docker/php ./bin/console --env=test doctrine:migrations:migrate --no-interaction
+	./bin-docker/php ./bin/console --env=test doctrine:schema:update --no-interaction --complete --force
 	./bin-docker/php ./bin/console --env=test doctrine:migration:sync-metadata-storage
 	./bin-docker/php ./bin/console --env=test assets:install
 	./bin-docker/yarn --cwd=tests/Application install --pure-lockfile
@@ -85,6 +88,7 @@ schema-reset:
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:drop --force --if-exists
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:create --no-interaction
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migrations:migrate --no-interaction
+	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:schema:update --no-interaction --complete --force
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migration:sync-metadata-storage
 
 fix:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ static-only:
 phpstan:
 	./bin-docker/docker-bash bin/phpstan.sh
 
+phpunit:
+	./bin-docker/docker-bash bin/phpunit.sh --testdox
+
 behat:
 	./bin-docker/docker-bash bin/behat.sh
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ run: init
 
 init:
 	which docker > /dev/null || (echo "Please install docker binary" && exit 1)
-	which direnv > /dev/null || (echo "Please install direnv binary" && exit 1)
-	if [ `command -v direnv &> /dev/null` ]; then \
+	if command -v direnv &> /dev/null; then \
 		cp --update=none .envrc.dist .envrc; \
 		direnv allow; \
 	fi
@@ -21,12 +20,11 @@ init:
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" assets:install
 	./bin-docker/yarn --cwd=tests/Application install --pure-lockfile
 	GULP_ENV=prod ./bin-docker/yarn --cwd=tests/Application build
-	chmod -R 777 tests/Application/var
+	@make var
 
 init-tests:
 	which docker > /dev/null || (echo "Please install docker binary" && exit 1)
-	which direnv > /dev/null || (echo "Please install direnv binary" && exit 1)
-	if [ `command -v direnv &> /dev/null` ]; then \
+	if command -v direnv &> /dev/null then \
 		cp --update=none .envrc.dist .envrc; \
 		direnv allow; \
 	fi
@@ -41,7 +39,7 @@ init-tests:
 	./bin-docker/php ./bin/console --env=test assets:install
 	./bin-docker/yarn --cwd=tests/Application install --pure-lockfile
 	GULP_ENV=prod ./bin-docker/yarn --cwd=tests/Application build
-	chmod -R 777 tests/Application/var
+	@make var
 
 cache:
 	./bin-docker/php ./bin/console --env="$(APP_ENV)" cache:clear
@@ -101,7 +99,7 @@ var:
 	mkdir -p tests/Application/var/log
 	touch tests/Application/var/log/test.log
 	touch tests/Application/var/log/dev.log
-	chmod -R 777 tests/Application/var
+	chmod -R 0777 tests/Application/var
 
 fixtures: schema-reset bare-fixtures
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 MAKEFLAGS += --no-print-directory # to disable "make: Entering directory ..." messages
 
-APP_ENV ?= dev
-
 run: init
 
 init:
@@ -16,11 +14,11 @@ init:
 	./bin-docker/composer install
 	rm -fr "tests/Application/var/$(APP_ENV)"
 	@make var
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:create --no-interaction --if-not-exists
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migrations:migrate --no-interaction
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:schema:update --no-interaction --complete --force
-	./bin-docker/php ./bin/console --env="$(APP_ENV)"  doctrine:migration:sync-metadata-storage
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" assets:install
+	./bin-docker/php ./bin/console doctrine:database:create --no-interaction --if-not-exists
+	./bin-docker/php ./bin/console doctrine:migrations:migrate --no-interaction
+	./bin-docker/php ./bin/console doctrine:schema:update --no-interaction --complete --force
+	./bin-docker/php ./bin/console doctrine:migration:sync-metadata-storage
+	./bin-docker/php ./bin/console assets:install
 	./bin-docker/yarn --cwd=tests/Application install --pure-lockfile
 	GULP_ENV=prod ./bin-docker/yarn --cwd=tests/Application build
 	@make var
@@ -45,7 +43,7 @@ init-tests:
 	@make var
 
 cache:
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" cache:clear
+	./bin-docker/php ./bin/console cache:clear
 	@make var
 
 static: fix static-only
@@ -88,18 +86,18 @@ yarn-build:
 make yarn: yarn-build
 
 schema-reset:
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:drop --force --if-exists
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:database:create --no-interaction
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migrations:migrate --no-interaction
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:schema:update --no-interaction --complete --force
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" doctrine:migration:sync-metadata-storage
+	./bin-docker/php ./bin/console doctrine:database:drop --force --if-exists
+	./bin-docker/php ./bin/console doctrine:database:create --no-interaction
+	./bin-docker/php ./bin/console doctrine:migrations:migrate --no-interaction
+	./bin-docker/php ./bin/console doctrine:schema:update --no-interaction --complete --force
+	./bin-docker/php ./bin/console doctrine:migration:sync-metadata-storage
 
 fix:
 	./bin-docker/docker-bash bin/ecs.sh --fix
 
 bare-fixtures:
 	@echo "############\nLoading fixtures: $(SPEED_MESSAGE)\n############"
-	./bin-docker/php ./bin/console --env="$(APP_ENV)" sylius:fixtures:load --no-interaction
+	./bin-docker/php ./bin/console sylius:fixtures:load --no-interaction
 
 var:
 	rm -fr tests/Application/var

--- a/bin-docker/composer
+++ b/bin-docker/composer
@@ -24,5 +24,5 @@ else
 	docker_compose_run \
 		--entrypoint=php \
 		--user="${CURRENT_USER_ID}:${CURRENT_GROUP_ID}" \
-		php /usr/local/bin/composer "$@"
+		php /usr/bin/composer "$@"
 fi

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symfony/http-kernel": "^v6.4|^v7.1",
         "symfony/intl": "^v6.4|^v7.1",
         "symfony/web-profiler-bundle": "^v6.4|^v7.1",
-        "symplify/easy-coding-standard": "^12.0"
+        "symplify/easy-coding-standard": "^12.0",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "conflict": {
         "api-platform/symfony": "<v4.1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "friends-of-behat/mink-extension": "^v2.7.5",
         "friends-of-behat/page-object-extension": "^v0.3.2",
         "friends-of-behat/suite-settings-extension": "^v1.1.0",
-        "friends-of-behat/symfony-extension": "v2.6.0",
+        "friends-of-behat/symfony-extension": "^2.6.2",
         "friends-of-behat/variadic-extension": "^v1.6.0",
         "php-http/message-factory": "^1.1.0",
         "phpstan/phpstan": "^2.1.10",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     },
     "require-dev": {
         "behat/behat": "^v3.19.0",
-        "dmore/behat-chrome-extension": "^1.4.0",
+        "dmore/behat-chrome-extension": "^1.4",
         "dmore/chrome-mink-driver": "^2.9.3",
-        "friends-of-behat/mink": "^v1.11.0",
+        "friends-of-behat/mink": "^1.11",
         "friends-of-behat/mink-browserkit-driver": "^v1.6.2",
         "friends-of-behat/mink-debug-extension": "^v2.1.0",
         "friends-of-behat/mink-extension": "^v2.7.5",
@@ -22,36 +22,40 @@
         "friends-of-behat/suite-settings-extension": "^v1.1.0",
         "friends-of-behat/symfony-extension": "^2.6.2",
         "friends-of-behat/variadic-extension": "^v1.6.0",
+        "nyholm/psr7": "^1.8",
         "php-http/message-factory": "^1.1.0",
         "phpstan/phpstan": "^2.1.10",
         "phpstan/phpstan-doctrine": "^2.0.2",
         "phpstan/phpstan-strict-rules": "^2.0.4",
         "phpstan/phpstan-symfony": "^2.0.3",
         "phpstan/phpstan-webmozart-assert": "^2.0.0",
+        "phpunit/phpunit": "^11.1 || ^12.0.10",
         "polishsymfonycommunity/symfony-mocker-container": "^v1.0.8",
         "rector/rector": "^2.0.10",
-        "phpunit/phpunit": "^11.5",
         "sylius-labs/coding-standard": "^v4.4.0",
         "symfony/browser-kit": "^v6.4|^v7.1",
         "symfony/debug-bundle": "^v6.4|^v7.1",
+        "symfony/doctrine-bridge": "^v6.4|^v7.1",
         "symfony/dotenv": "^v6.4|^v7.1",
         "symfony/flex": "^v2.5.0",
         "symfony/framework-bundle": "^v6.4|^v7.1",
         "symfony/http-foundation": "^v7.2.3",
         "symfony/http-kernel": "^v6.4|^v7.1",
         "symfony/intl": "^v6.4|^v7.1",
+        "symfony/property-info": "^v6.4|^v7.1",
         "symfony/web-profiler-bundle": "^v6.4|^v7.1",
-        "symplify/easy-coding-standard": "^12.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "symplify/easy-coding-standard": "^12.0"
     },
     "conflict": {
         "api-platform/symfony": "<v4.1.0",
         "api-platform/core": "<2.7.13",
-        "babdev/pagerfanta-bundle": "<3.6.1",
+        "babdev/pagerfanta-bundle": "<3.7.0",
         "doctrine/collections": "<1.7.0",
         "doctrine/data-fixtures": "<1.5.1",
         "doctrine/dbal": "<2.13.3",
         "doctrine/doctrine-bundle": "<2.13.1",
+        "doctrine/orm": "<2.19.0",
+        "fakerphp/faker": "<1.21.0",
         "friendsofsymfony/rest-bundle": "<3.1.0",
         "jms/serializer-bundle": "<4.2.0",
         "masterminds/html5": "<2.7.5",
@@ -59,14 +63,16 @@
         "lexik/jwt-authentication-bundle": "<2.12",
         "payum/core": "<1.7.3",
         "polishsymfonycommunity/symfony-mocker-container": "<1.0.6",
+        "sylius/grid-bundle": "<1.11.0",
         "sylius/resource-bundle": "<1.11.0",
         "sylius/sylius": "<2.0.6",
         "symfony/css-selector": "<4.4.24",
         "symfony/framework-bundle": ">=5.4.0 <=5.4.20|>=6.0.0 <=6.0.16|>=6.1.0 <=6.1.8|>=6.2.0 <=6.2.2|6.2.8",
+        "symfony/dom-crawler": "<5.4.0",
         "symfony/mime": "<5.4.0",
         "symfony/validator": "7.3.0",
         "symfony/web-link": "<5.3.0",
-        "symplify/easy-coding-standard": "<10.2.0|12.5.10",
+        "symplify/easy-coding-standard": "<10.3.0|12.5.10",
         "twig/twig": "<2.14.7",
         "webmozart/assert": "<1.11.0",
         "willdurand/negotiation": "<3.0"
@@ -92,9 +98,19 @@
         }
     },
     "scripts": {
+        "post-install-cmd": [
+            "php bin/create_node_symlink.php"
+        ],
+        "post-update-cmd": [
+            "php bin/create_node_symlink.php"
+        ],
+        "post-create-project-cmd": [
+            "php bin/create_node_symlink.php"
+        ],
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "COMPOSER_AUDIT_ABANDONED=ignore composer audit": "script"
         }
     }
 }

--- a/tests/Application/src/Kernel.php
+++ b/tests/Application/src/Kernel.php
@@ -20,13 +20,6 @@ final class Kernel extends BaseKernel
 
     private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function __construct(
-        string $environment,
-        bool   $debug,
-    ) {
-        parent::__construct($environment, $debug);
-    }
-
     public function getCacheDir(): string
     {
         return $this->getProjectDir() . '/var/cache/' . $this->environment;


### PR DESCRIPTION
`squizlabs/php_codesniffer:4` even with latest `slevomat/coding-standard` caused crash when running `vendor/bin/ecs`